### PR TITLE
Implement model scopes

### DIFF
--- a/lib/auto_increment/incrementor.rb
+++ b/lib/auto_increment/incrementor.rb
@@ -11,6 +11,7 @@ module AutoIncrement
       @column = column || options[:column] || :code
       @options = options.reverse_merge scope: nil, initial: 1, force: false
       @options[:scope] = [@options[:scope]] unless @options[:scope].is_a? Array
+      @options[:model_scopes] = [@options[:model_scopes]] unless @options[:model_scopes].is_a? Array
     end
 
     def before_create(record)
@@ -41,8 +42,16 @@ module AutoIncrement
       query
     end
 
+    def build_model_scopes(query)
+      @options[:model_scopes].reject(&:nil?).each do |scope|
+        query = query.send(scope)
+      end
+
+      query
+    end
+
     def maximum
-      query = build_scopes @record.class
+      query = build_scopes(build_model_scopes(@record.class))
       query.lock if lock?
 
       if string?

--- a/spec/lib/active_record_spec.rb
+++ b/spec/lib/active_record_spec.rb
@@ -7,17 +7,19 @@ describe AutoIncrement do
     @account1 = Account.create name: 'My Account'
     @account2 = Account.create name: 'Another Account', code: 50
 
-    @user_account1 = @account1.users.create name: 'Felipe', letter_code: 'Z'
-    @user_account2 = @account2.users.create name: 'Daniel'
+    @user1_account1 = @account1.users.create name: 'Felipe', letter_code: 'Z'
+    @user1_account2 = @account2.users.create name: 'Daniel'
+    @user2_account2 = @account2.users.create name: 'Mark'
+    @user3_account2 = @account2.users.create name: 'Robert'
   end
 
   describe 'initial' do
     it { expect(@account1.code).to eq 1 }
-    it { expect(@user_account1.letter_code).to eq 'A' }
+    it { expect(@user1_account1.letter_code).to eq 'A' }
   end
 
   describe 'do not increment outside scope' do
-    it { expect(@user_account2.letter_code).to eq 'A' }
+    it { expect(@user1_account2.letter_code).to eq 'A' }
   end
 
   describe 'not set column if is already set' do
@@ -25,7 +27,7 @@ describe AutoIncrement do
   end
 
   describe 'set column if option force is used' do
-    it { expect(@user_account1.letter_code).to eq 'A' }
+    it { expect(@user1_account1.letter_code).to eq 'A' }
   end
 
   describe 'locks query for increment' do
@@ -59,5 +61,9 @@ describe AutoIncrement do
     account3.valid?
 
     it { expect(account3.code).not_to be_nil }
+  end
+
+  describe 'uses model scopes' do
+    it { expect(@user3_account2.letter_code).to eq('C') }
   end
 end

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -1,7 +1,11 @@
 # + Spec +User+
 class User < ActiveRecord::Base
   auto_increment :letter_code, scope: :account_id, initial: 'A', force: true,
-                               lock: true
+                               lock: true, model_scopes: [:with_mark]
 
   belongs_to :account
+
+  default_scope -> { where 'name <> ?', 'Mark' }
+
+  scope :with_mark, -> { unscoped }
 end


### PR DESCRIPTION
In our project, we use the Paranoia gem, which adds a `default_scope` filtering out all the deleted records. 

This works well pretty much everywhere for us, except in our auto-increment columns, because we still want to increment the ID when the previous record is deleted.

Paranoia provides a nice `with_deleted` method to remove the default scope, but there is no way to call it when determining the next auto-incremental ID currently. We solved this with this patch:

```ruby
AutoIncrement::Incrementor.prepend (Module.new do
  def build_scopes(*)
    relation = super
    relation = relation.with_deleted if relation.respond_to?(:with_deleted)
    relation
  end
end)
```

But we thought we'd give back to the community and make a PR for it.

I'm not sure if the test case makes much sense. It's what I came up with that didn't require modifying the structure of the DB. Let me know if you'd like me to improve it.