### PR TITLE
Fixing Lock problem, and Adding Support For Advisory Lock

### DIFF
--- a/lib/auto_increment/incrementor.rb
+++ b/lib/auto_increment/incrementor.rb
@@ -51,15 +51,17 @@ module AutoIncrement
     end
 
     def maximum
-      query = build_scopes(build_model_scope(@record.class))
-      query.lock if lock?
+      @record.class.transaction do
+        query = build_scopes(build_model_scope(@record.class))
+        query.lock if lock?
 
-      if string?
-        query.select("#{@column} max")
-             .order(Arel.sql("LENGTH(#{@column}) DESC, #{@column} DESC"))
-             .first.try :max
-      else
-        query.maximum @column
+        if string?
+          query.select("#{@column} max")
+               .order(Arel.sql("LENGTH(#{@column}) DESC, #{@column} DESC"))
+               .first.try :max
+        else
+          query.maximum @column
+        end
       end
     end
 


### PR DESCRIPTION
Lock fails because lock method works only inside a transaction block.
And I've added as well an advisory table lock capability which is more consistent and it will not affect the performance of other queries on that table.