### PR TITLE
Update activerecord/activesupport constraints to allow Rails 6

### DIFF
--- a/auto_increment.gemspec
+++ b/auto_increment.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'appraisal'
 
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
 end

--- a/auto_increment.gemspec
+++ b/auto_increment.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_dependency 'activerecord', '>= 4.0', '< 5.3'
-  s.add_dependency 'activesupport', '>= 4.0', '< 5.3'
+  s.add_dependency 'activerecord', '>= 4.0', '< 6.0'
+  s.add_dependency 'activesupport', '>= 4.0', '< 6.0'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Rails 6 is currently in [beta2](https://weblog.rubyonrails.org/2019/2/25/Rails-6-0-beta2-released/) and some large shops are already running it in production; this PR updates the dependency constraints to allow for Rails 6.