### PR TITLE
feat: Support using model_scope for scopes which have arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ First argument is the column that will be incremented. Can be integer or string.
 * lock: you can set a lock on the max query. (default: false)
 * before: you can choose a different callback to be used (:create, :save, :validation) (default: create)
 
+```rb
+auto_increment :letter, scope: [:account_id, :job_id], model_scope: {scope: :in_account, arg: account_id}, initial: 'C', force: true, lock: false, before: :create
+```
+* model_scope: you can define model scopes ( arguments scopes ) that will be executed and you can use as many as you want (default: nil)
 
 ## Compatibility
 

--- a/lib/auto_increment/incrementor.rb
+++ b/lib/auto_increment/incrementor.rb
@@ -44,7 +44,18 @@ module AutoIncrement
 
     def build_model_scope(query)
       @options[:model_scope].reject(&:nil?).each do |scope|
-        query = query.send(scope)
+        if scope.is_a? Hash
+          scp = scope[:scope]
+          arg = scope[:arg]
+        else
+          scp = scope
+        end
+
+        query = if arg.present?
+                  query.send(scp, arg)
+                else
+                  query.send(scp)
+                end
       end
 
       query


### PR DESCRIPTION
Keeping Support for argumentless model_scopes and support the argument scopes too