### PR TITLE
Remove deprecation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auto_increment (1.5.2)
+    auto_increment (1.6.0)
       activerecord (>= 6.0)
       activesupport (>= 6.0)
 

--- a/lib/auto_increment/incrementor.rb
+++ b/lib/auto_increment/incrementor.rb
@@ -14,8 +14,6 @@ module AutoIncrement
       @options = options.reverse_merge initial: 1, force: false
       @options[:scope] = [@options[:scope]].compact unless @options[:scope].is_a?(Array)
       @options[:model_scope] = [@options[:model_scope]].compact unless @options[:model_scope].is_a?(Array)
-
-      deprecated_warning
     end
 
     def before_create(record)
@@ -77,14 +75,6 @@ module AutoIncrement
 
     def string?
       @options[:initial].instance_of?(String)
-    end
-
-    def deprecated_warning
-      return if @options[:scope].empty?
-
-      ActiveSupport::Deprecation.warn <<~WARNING.squish
-        Passing a scope to auto_increment is deprecated and will be removed in the next version. Please use model_scope instead.
-      WARNING
     end
   end
 end

--- a/spec/lib/incrementor_spec.rb
+++ b/spec/lib/incrementor_spec.rb
@@ -30,23 +30,4 @@ describe AutoIncrement::Incrementor do
       expect(subject.send(:increment)).to eq 'A'
     end
   end
-
-  describe 'deprecates scope' do
-    subject { AutoIncrement::Incrementor.new :code, **options }
-    let(:options) { { scope: :account_id } }
-
-    it 'issues a deprecation warning' do
-      expect(ActiveSupport::Deprecation).to receive(:warn).with(/Passing a scope to auto_increment is deprecated/)
-      subject
-    end
-
-    context 'when @options[:scope] is not present' do
-      let(:options) { {} }
-
-      it 'does not issue a deprecation warning' do
-        expect(ActiveSupport::Deprecation).not_to receive(:warn)
-        subject
-      end
-    end
-  end
 end


### PR DESCRIPTION
`scope` can't be fully replaced `model_scope`, so the warning is being removed.