### PR TITLE
Add thread safety

### DIFF
--- a/lib/auto_increment/active_record.rb
+++ b/lib/auto_increment/active_record.rb
@@ -7,12 +7,10 @@ module AutoIncrement
     extend ActiveSupport::Concern
     # +AutoIncrement::ActiveRecord::ClassMethods+
     module ClassMethods
-      def auto_increment(column = nil, options = {})
-        options.reverse_merge! before: :create
-
-        callback = "before_#{options[:before]}"
-
-        send callback, Incrementor.new(column, options)
+      def auto_increment(column = nil, **options)
+        send("before_#{options.fetch(:before, :create)}") do |record|
+          Incrementor.new(record, column, **options).run
+        end
       end
     end
   end

--- a/spec/lib/incrementor_spec.rb
+++ b/spec/lib/incrementor_spec.rb
@@ -13,6 +13,10 @@ describe AutoIncrement::Incrementor do
     'AAAAA' => 'AAAAB'
   }.each do |previous_value, next_value|
     describe "increment value for #{previous_value}" do
+      subject do
+        AutoIncrement::Incrementor.new User.new
+      end
+
       it do
         allow(subject).to receive(:maximum) { previous_value }
         expect(subject.send(:increment)).to eq next_value
@@ -22,7 +26,7 @@ describe AutoIncrement::Incrementor do
 
   describe 'initial value of string' do
     subject do
-      AutoIncrement::Incrementor.new initial: 'A'
+      AutoIncrement::Incrementor.new User.new, initial: 'A'
     end
 
     it do


### PR DESCRIPTION
Hi @felipediesel!

I think that this gem is not thread safe due to this code:

```ruby
# lib/auto_increment/incrementor.rb

def before_create(record)
  @record = record
  write if can_write?
end
```

`Incrementor` instance is shared between all instances of model that includes the `auto_increment` due to this:

```ruby
# lib/auto_increment/active_record.rb

send callback, Incrementor.new(column, options)
```

In theory, an instance of the model can execute its callback and set `@record` in the shared instance of the `Incrementor` and while the rest of the methods initiated by `write` are executed another instance of the model can overwrite the value of the record, used to calculate the scopes and the maximum stored value.

I will try to fix this issue in this PR, what do you think?