### PR TITLE
Fix locked relation chaining

### DIFF
--- a/lib/auto_increment/incrementor.rb
+++ b/lib/auto_increment/incrementor.rb
@@ -28,6 +28,13 @@ module AutoIncrement
       @record.send :write_attribute, @column, increment
     end
 
+    def maximum_query
+      query = build_scopes(build_model_scope(@record.class))
+      query = query.lock if lock?
+
+      query
+    end
+
     def build_scopes(query)
       @scope.each do |scope|
         query = query.where(scope => @record.send(scope)) if @record.respond_to?(scope)
@@ -45,8 +52,7 @@ module AutoIncrement
     end
 
     def maximum
-      query = build_scopes(build_model_scope(@record.class))
-      query.lock if lock?
+      query = maximum_query
 
       if string?
         query.select("#{@column} max")

--- a/spec/lib/incrementor_spec.rb
+++ b/spec/lib/incrementor_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "models/account"
+require "models/user"
 
 describe AutoIncrement::Incrementor do
   {
@@ -32,6 +34,18 @@ describe AutoIncrement::Incrementor do
     it do
       allow(subject).to receive(:maximum) { nil }
       expect(subject.send(:increment)).to eq "A"
+    end
+  end
+
+  describe "locking the query" do
+    subject do
+      AutoIncrement::Incrementor.new Account.new, :code, lock: true
+    end
+
+    it "returns a locked relation for the maximum query" do
+      relation = subject.send(:maximum_query)
+
+      expect(relation.lock_value).to eq(true)
     end
   end
 end


### PR DESCRIPTION
When lock is enabled, the relation must be reassigned before running the maximum query. Otherwise the lock call is dropped and the unlocked relation is used.

Original comment: https://github.com/felipediesel/auto_increment/issues/6#issuecomment-4385067208
