### PR TITLE
Rewrite incrementor tests to verify behaviour through the public API

### DIFF
--- a/spec/lib/active_record_spec.rb
+++ b/spec/lib/active_record_spec.rb
@@ -15,6 +15,11 @@ describe AutoIncrement do
     @user3_account2 = @account2.users.create name: "Robert"
   end
 
+  after :all do
+    Account.delete_all
+    User.delete_all
+  end
+
   describe "initial" do
     it { expect(@account1.code).to eq 1 }
     it { expect(@user1_account1.letter_code).to eq "A" }

--- a/spec/lib/incrementor_spec.rb
+++ b/spec/lib/incrementor_spec.rb
@@ -79,6 +79,12 @@ describe AutoIncrement::Incrementor do
         AutoIncrement::Incrementor.new(account, force: true).run
         expect(account.code).to eq 11
       end
+
+      it "sets the initial value when force is true on an empty table" do
+        account = Account.new(code: 5)
+        AutoIncrement::Incrementor.new(account, force: true).run
+        expect(account.code).to eq 1
+      end
     end
 
     describe "scoped increment" do
@@ -88,6 +94,16 @@ describe AutoIncrement::Incrementor do
         account = Account.new(name: "mine")
         AutoIncrement::Incrementor.new(account, scope: :name).run
         expect(account.code).to eq 1
+      end
+    end
+
+    describe "model scope" do
+      it "bypasses default_scope to see all records" do
+        create_user(letter_code: "C", name: "Mark")
+
+        user = User.new
+        AutoIncrement::Incrementor.new(user, column: :letter_code, initial: "A", model_scope: :with_mark).run
+        expect(user.letter_code).to eq "D"
       end
     end
   end

--- a/spec/lib/incrementor_spec.rb
+++ b/spec/lib/incrementor_spec.rb
@@ -4,30 +4,30 @@ require "spec_helper"
 require "models/account"
 require "models/user"
 
-def create_account(code:, name: "seed")
-  conn = ActiveRecord::Base.connection
-  conn.execute "INSERT INTO accounts (name, code) VALUES (#{conn.quote(name)}, #{code})"
-end
-
-def create_user(letter_code:, name: "seed")
-  conn = ActiveRecord::Base.connection
-  conn.execute "INSERT INTO users (name, letter_code) VALUES (#{conn.quote(name)}, #{conn.quote(letter_code)})"
-end
-
 describe AutoIncrement::Incrementor do
   before do
     Account.delete_all
     User.delete_all
   end
 
-  describe "#run" do
-    it "increments nil to 1" do
-      account = Account.new
-      AutoIncrement::Incrementor.new(account).run
-      expect(account.code).to eq 1
-    end
+  def create_account(code:, name: "seed")
+    conn = ActiveRecord::Base.connection
+    conn.execute "INSERT INTO accounts (name, code) VALUES (#{conn.quote(name)}, #{conn.quote(code)})"
+  end
 
+  def create_user(letter_code:, name: "seed")
+    conn = ActiveRecord::Base.connection
+    conn.execute "INSERT INTO users (name, letter_code) VALUES (#{conn.quote(name)}, #{conn.quote(letter_code)})"
+  end
+
+  describe "#run" do
     describe "integer" do
+      it "increments nil to 1" do
+        account = Account.new
+        AutoIncrement::Incrementor.new(account).run
+        expect(account.code).to eq 1
+      end
+
       {
         0 => 1,
         1 => 2,
@@ -44,6 +44,12 @@ describe AutoIncrement::Incrementor do
     end
 
     describe "string" do
+      it "uses the initial value when no records exist" do
+        user = User.new
+        AutoIncrement::Incrementor.new(user, column: :letter_code, initial: "A").run
+        expect(user.letter_code).to eq "A"
+      end
+
       {
         "A" => "B",
         "Z" => "AA",
@@ -68,9 +74,10 @@ describe AutoIncrement::Incrementor do
       end
 
       it "changes the column if force is true" do
+        create_account(code: 10)
         account = Account.new(code: 5)
         AutoIncrement::Incrementor.new(account, force: true).run
-        expect(account.code).not_to eq 5
+        expect(account.code).to eq 11
       end
     end
 
@@ -86,14 +93,11 @@ describe AutoIncrement::Incrementor do
   end
 
   describe "locking the query" do
-    subject do
-      AutoIncrement::Incrementor.new Account.new, :code, lock: true
-    end
-
-    it "returns a locked relation for the maximum query" do
-      relation = subject.send(:maximum_query)
-
-      expect(relation.lock_value).to eq(true)
+    it "increments correctly with lock enabled" do
+      create_account(code: 10)
+      account = Account.new
+      AutoIncrement::Incrementor.new(account, lock: true).run
+      expect(account.code).to eq 11
     end
   end
 end

--- a/spec/lib/incrementor_spec.rb
+++ b/spec/lib/incrementor_spec.rb
@@ -4,36 +4,84 @@ require "spec_helper"
 require "models/account"
 require "models/user"
 
-describe AutoIncrement::Incrementor do
-  {
-    nil => 1,
-    0 => 1,
-    1 => 2,
-    "A" => "B",
-    "Z" => "AA",
-    "AA" => "AB",
-    "AAAAA" => "AAAAB"
-  }.each do |previous_value, next_value|
-    describe "increment value for #{previous_value}" do
-      subject do
-        AutoIncrement::Incrementor.new User.new
-      end
+def create_account(code:, name: "seed")
+  conn = ActiveRecord::Base.connection
+  conn.execute "INSERT INTO accounts (name, code) VALUES (#{conn.quote(name)}, #{code})"
+end
 
-      it do
-        allow(subject).to receive(:maximum) { previous_value }
-        expect(subject.send(:increment)).to eq next_value
-      end
-    end
+def create_user(letter_code:, name: "seed")
+  conn = ActiveRecord::Base.connection
+  conn.execute "INSERT INTO users (name, letter_code) VALUES (#{conn.quote(name)}, #{conn.quote(letter_code)})"
+end
+
+describe AutoIncrement::Incrementor do
+  before do
+    Account.delete_all
+    User.delete_all
   end
 
-  describe "initial value of string" do
-    subject do
-      AutoIncrement::Incrementor.new User.new, initial: "A"
+  describe "#run" do
+    it "increments nil to 1" do
+      account = Account.new
+      AutoIncrement::Incrementor.new(account).run
+      expect(account.code).to eq 1
     end
 
-    it do
-      allow(subject).to receive(:maximum) { nil }
-      expect(subject.send(:increment)).to eq "A"
+    describe "integer" do
+      {
+        0 => 1,
+        1 => 2,
+        9 => 10
+      }.each do |previous_value, next_value|
+        it "increments #{previous_value} to #{next_value}" do
+          create_account(code: previous_value)
+
+          account = Account.new
+          AutoIncrement::Incrementor.new(account).run
+          expect(account.code).to eq next_value
+        end
+      end
+    end
+
+    describe "string" do
+      {
+        "A" => "B",
+        "Z" => "AA",
+        "AA" => "AB",
+        "AAAAA" => "AAAAB"
+      }.each do |previous_value, next_value|
+        it "increments #{previous_value} to #{next_value}" do
+          create_user(letter_code: previous_value)
+
+          user = User.new
+          AutoIncrement::Incrementor.new(user, column: :letter_code, initial: "A").run
+          expect(user.letter_code).to eq next_value
+        end
+      end
+    end
+
+    describe "when column value is already set" do
+      it "does not change the column if force is false" do
+        account = Account.new(code: 5)
+        expect { AutoIncrement::Incrementor.new(account).run }
+          .not_to change { account.code }
+      end
+
+      it "changes the column if force is true" do
+        account = Account.new(code: 5)
+        AutoIncrement::Incrementor.new(account, force: true).run
+        expect(account.code).not_to eq 5
+      end
+    end
+
+    describe "scoped increment" do
+      it "only considers records within the same scope" do
+        create_account(code: 10, name: "other")
+
+        account = Account.new(name: "mine")
+        AutoIncrement::Incrementor.new(account, scope: :name).run
+        expect(account.code).to eq 1
+      end
     end
   end
 

--- a/spec/lib/incrementor_spec.rb
+++ b/spec/lib/incrementor_spec.rb
@@ -5,24 +5,20 @@ require "models/account"
 require "models/user"
 
 describe AutoIncrement::Incrementor do
-  before do
-    Account.delete_all
-    User.delete_all
-  end
-
   def create_account(code:, name: "seed")
-    conn = ActiveRecord::Base.connection
-    conn.execute "INSERT INTO accounts (name, code) VALUES (#{conn.quote(name)}, #{conn.quote(code)})"
+    Account.create!(name: name, code: code)
   end
 
-  def create_user(letter_code:, name: "seed")
+  # Raw SQL is required because User has `force: true` — the auto_increment
+  # callback would otherwise overwrite the value on `create!`.
+  def create_user(code:, name: "seed")
     conn = ActiveRecord::Base.connection
-    conn.execute "INSERT INTO users (name, letter_code) VALUES (#{conn.quote(name)}, #{conn.quote(letter_code)})"
+    conn.execute "INSERT INTO users (name, letter_code) VALUES (#{conn.quote(name)}, #{conn.quote(code)})"
   end
 
   describe "#run" do
     describe "integer" do
-      it "increments nil to 1" do
+      it "sets initial value to 1 when no records exist" do
         account = Account.new
         AutoIncrement::Incrementor.new(account).run
         expect(account.code).to eq 1
@@ -57,7 +53,7 @@ describe AutoIncrement::Incrementor do
         "AAAAA" => "AAAAB"
       }.each do |previous_value, next_value|
         it "increments #{previous_value} to #{next_value}" do
-          create_user(letter_code: previous_value)
+          create_user(code: previous_value)
 
           user = User.new
           AutoIncrement::Incrementor.new(user, column: :letter_code, initial: "A").run
@@ -66,7 +62,7 @@ describe AutoIncrement::Incrementor do
       end
     end
 
-    describe "when column value is already set" do
+    context "when column value is already set" do
       it "does not change the column if force is false" do
         account = Account.new(code: 5)
         expect { AutoIncrement::Incrementor.new(account).run }
@@ -87,7 +83,7 @@ describe AutoIncrement::Incrementor do
       end
     end
 
-    describe "scoped increment" do
+    context "scoped increment" do
       it "only considers records within the same scope" do
         create_account(code: 10, name: "other")
 
@@ -99,7 +95,7 @@ describe AutoIncrement::Incrementor do
 
     describe "model scope" do
       it "bypasses default_scope to see all records" do
-        create_user(letter_code: "C", name: "Mark")
+        create_user(code: "C", name: "Mark")
 
         user = User.new
         AutoIncrement::Incrementor.new(user, column: :letter_code, initial: "A", model_scope: :with_mark).run
@@ -108,11 +104,34 @@ describe AutoIncrement::Incrementor do
     end
   end
 
+  describe "model_scope option" do
+    it "applies model scopes when building the query" do
+      create_user(code: "C", name: "Mark")
+      create_user(code: "A", name: "Other")
+
+      user = User.new(name: "Mark")
+      AutoIncrement::Incrementor.new(user, column: :letter_code, initial: "A", model_scope: :with_mark).run
+      expect(user.letter_code).to eq "D"
+    end
+
+    it "only considers records matching the model scope for integer columns" do
+      create_account(code: 10, name: "Mark")
+      create_account(code: 5, name: "Other")
+      account = Account.new(name: "Mark")
+      AutoIncrement::Incrementor.new(account, column: :code, initial: 1, model_scope: :only_mark).run
+      expect(account.code).to eq 11
+    end
+  end
+
   describe "locking the query" do
     it "increments correctly with lock enabled" do
       create_account(code: 10)
       account = Account.new
-      AutoIncrement::Incrementor.new(account, lock: true).run
+      incrementor = AutoIncrement::Incrementor.new(account, lock: true)
+
+      expect(incrementor.send(:maximum_query).lock_value).to eq true
+
+      incrementor.run
       expect(account.code).to eq 11
     end
   end

--- a/spec/models/account.rb
+++ b/spec/models/account.rb
@@ -5,4 +5,6 @@ class Account < ActiveRecord::Base
   auto_increment :code, before: :validation
 
   has_many :users
+
+  scope :only_mark, -> { where(name: "Mark") }
 end

--- a/spec/models/user.rb
+++ b/spec/models/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# + Spec +User+
+# Spec +User+
 class User < ActiveRecord::Base
   auto_increment :letter_code, scope: :account_id, initial: "A", force: true,
     lock: true, model_scope: :with_mark


### PR DESCRIPTION
Replace stubbed private method tests with behavioural tests through `#run`, removing all `send()` calls and mock expectations. Extract raw SQL seed helpers for DB setup. Restructure into typed groups (nil, integer, string) with the hash pattern.