### PR TITLE
Fix auto_increment on string columns with integer initial

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ AB
 
 String sequences follow Ruby's [`String#next`](https://ruby-doc.org/3.4/Object.html#method-i-next) logic. The column type is inferred from the database schema.
 
+> **Deprecation**: Explicitly passing an initial value whose type differs from the database column type is deprecated. For example, `auto_increment :ref, initial: 1` on a `string` column will emit a warning. When `initial` is not set, the default is automatically inferred from the column type (`"1"` for string columns, `1` for integer columns).
+
 ### Scoped Sequences
 
 Generate independent sequences within a scope:
@@ -249,7 +251,7 @@ auto_increment :number,
 | Option        | Description                                                        | Default   |
 | ------------- | ------------------------------------------------------------------ | --------- |
 | `column`      | Column to increment. Can be integer or string.                     | `:code`   |
-| `initial`     | Starting value. Inferred from the database column type.            | `1`       |
+| `initial`     | Starting value. Must match the database column type (`Integer` for integer columns, `String` for string columns). | `1`       |
 | `scope`       | Restricts the sequence to matching column values.                  | `nil`     |
 | `model_scope` | Applies Active Record scopes before calculating the maximum value. | `nil`     |
 | `force`       | Overwrites an already assigned value.                              | `false`   |

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ AB
 ...
 ```
 
-String sequences follow the same pattern as Excel columns.
+String sequences follow Ruby's [`String#next`](https://ruby-doc.org/3.4/Object.html#method-i-next) logic.
 
 ### Scoped Sequences
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ AB
 ...
 ```
 
-String sequences follow Ruby's [`String#next`](https://ruby-doc.org/3.4/Object.html#method-i-next) logic.
+String sequences follow Ruby's [`String#next`](https://ruby-doc.org/3.4/Object.html#method-i-next) logic. The column type is inferred from the database schema.
 
 ### Scoped Sequences
 
@@ -249,7 +249,7 @@ auto_increment :number,
 | Option        | Description                                                        | Default   |
 | ------------- | ------------------------------------------------------------------ | --------- |
 | `column`      | Column to increment. Can be integer or string.                     | `:code`   |
-| `initial`     | Starting value. Integer or string.                                 | `1`       |
+| `initial`     | Starting value. Inferred from the database column type.            | `1`       |
 | `scope`       | Restricts the sequence to matching column values.                  | `nil`     |
 | `model_scope` | Applies Active Record scopes before calculating the maximum value. | `nil`     |
 | `force`       | Overwrites an already assigned value.                              | `false`   |

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ AB
 ...
 ```
 
-String sequences follow Ruby's [`String#next`](https://ruby-doc.org/3.4/Object.html#method-i-next) logic. The column type is inferred from the database schema.
+String sequences follow Ruby's [`String#next`](https://ruby-doc.org/3.4/String.html#method-i-next) logic. The column type is inferred from the database schema.
 
 > **Deprecation**: Explicitly passing an initial value whose type differs from the database column type is deprecated. For example, `auto_increment :ref, initial: 1` on a `string` column will emit a warning. When `initial` is not set, the default is automatically inferred from the column type (`"1"` for string columns, `1` for integer columns).
 
@@ -251,7 +251,7 @@ auto_increment :number,
 | Option        | Description                                                        | Default   |
 | ------------- | ------------------------------------------------------------------ | --------- |
 | `column`      | Column to increment. Can be integer or string.                     | `:code`   |
-| `initial`     | Starting value. Must match the database column type (`Integer` for integer columns, `String` for string columns). | `1`       |
+| `initial`     | Starting value. Must match the database column type (`Integer` for integer columns, `String` for string columns). When omitted, inferred from the column type. | `1` or `"1"` (inferred) |
 | `scope`       | Restricts the sequence to matching column values.                  | `nil`     |
 | `model_scope` | Applies Active Record scopes before calculating the maximum value. | `nil`     |
 | `force`       | Overwrites an already assigned value.                              | `false`   |

--- a/lib/auto_increment/active_record.rb
+++ b/lib/auto_increment/active_record.rb
@@ -28,11 +28,15 @@ module AutoIncrement
         return if col_type == :integer && initial.is_a?(Integer)
         return if col_type.in?(%i[string text]) && initial.is_a?(String)
 
+        model_name = name.presence || "anonymous"
+
         warn(
           "[DEPRECATION] The initial value type (#{initial.class}) does not match " \
-          "the column type (#{col_type}) for column '#{column}' on #{name}. " \
+          "the column type (#{col_type}) for column '#{column}' on #{model_name}. " \
           "This behavior is deprecated and will raise an error in the future."
         )
+      rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError
+        # Ignore connection/schema errors during class loading
       end
     end
   end

--- a/lib/auto_increment/active_record.rb
+++ b/lib/auto_increment/active_record.rb
@@ -10,23 +10,29 @@ module AutoIncrement
     module ClassMethods
       def auto_increment(column = nil, **options)
         column ||= options.fetch(:column, :code)
-        initial = options.fetch(:initial, 1)
-        col = columns_hash[column.to_s]
-        if col
-          col_type = col.type
-          if (col_type == :integer && !initial.is_a?(Integer)) ||
-              (col_type.in?(%i[string text]) && !initial.is_a?(String))
-            warn(
-              "[DEPRECATION] The initial value type (#{initial.class}) does not match " \
-              "the column type (#{col_type}) for column '#{column}' on #{name}. " \
-              "This behavior is deprecated and will raise an error in the future."
-            )
-          end
-        end
+
+        auto_increment_deprecate_type_mismatch(column, options[:initial]) if options.key?(:initial)
 
         send("before_#{options.fetch(:before, :create)}") do |record|
           Incrementor.new(record, column, **options).run
         end
+      end
+
+      private
+
+      def auto_increment_deprecate_type_mismatch(column, initial)
+        col = columns_hash[column.to_s]
+        return unless col
+
+        col_type = col.type
+        return if col_type == :integer && initial.is_a?(Integer)
+        return if col_type.in?(%i[string text]) && initial.is_a?(String)
+
+        warn(
+          "[DEPRECATION] The initial value type (#{initial.class}) does not match " \
+          "the column type (#{col_type}) for column '#{column}' on #{name}. " \
+          "This behavior is deprecated and will raise an error in the future."
+        )
       end
     end
   end

--- a/lib/auto_increment/active_record.rb
+++ b/lib/auto_increment/active_record.rb
@@ -9,6 +9,21 @@ module AutoIncrement
     # +AutoIncrement::ActiveRecord::ClassMethods+
     module ClassMethods
       def auto_increment(column = nil, **options)
+        column ||= options.fetch(:column, :code)
+        initial = options.fetch(:initial, 1)
+        col = columns_hash[column.to_s]
+        if col
+          col_type = col.type
+          if (col_type == :integer && !initial.is_a?(Integer)) ||
+              (col_type.in?(%i[string text]) && !initial.is_a?(String))
+            warn(
+              "[DEPRECATION] The initial value type (#{initial.class}) does not match " \
+              "the column type (#{col_type}) for column '#{column}' on #{name}. " \
+              "This behavior is deprecated and will raise an error in the future."
+            )
+          end
+        end
+
         send("before_#{options.fetch(:before, :create)}") do |record|
           Incrementor.new(record, column, **options).run
         end

--- a/lib/auto_increment/active_record.rb
+++ b/lib/auto_increment/active_record.rb
@@ -21,7 +21,12 @@ module AutoIncrement
       private
 
       def auto_increment_deprecate_type_mismatch(column, initial)
-        col = columns_hash[column.to_s]
+        col = begin
+          columns_hash[column.to_s]
+        rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError
+          # Ignore connection/schema errors during class loading
+          return
+        end
         return unless col
 
         col_type = col.type
@@ -35,8 +40,6 @@ module AutoIncrement
           "the column type (#{col_type}) for column '#{column}' on #{model_name}. " \
           "This behavior is deprecated and will raise an error in the future."
         )
-      rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError
-        # Ignore connection/schema errors during class loading
       end
     end
   end

--- a/lib/auto_increment/incrementor.rb
+++ b/lib/auto_increment/incrementor.rb
@@ -74,7 +74,12 @@ module AutoIncrement
     end
 
     def string?
-      @initial.instance_of?(String)
+      @initial.instance_of?(String) || column_string?
+    end
+
+    def column_string?
+      col = @record.class.columns_hash[@column.to_s]
+      col && col.type.in?(%i[string text])
     end
   end
 end

--- a/lib/auto_increment/incrementor.rb
+++ b/lib/auto_increment/incrementor.rb
@@ -79,7 +79,7 @@ module AutoIncrement
 
     def column_string?
       col = @record.class.columns_hash[@column.to_s]
-      col && col.type.in?(%i[string text])
+      col&.type&.in?(%i[string text])
     end
   end
 end

--- a/lib/auto_increment/incrementor.rb
+++ b/lib/auto_increment/incrementor.rb
@@ -55,8 +55,9 @@ module AutoIncrement
       query = maximum_query
 
       if column_string?
-        query.select("#{@column} max")
-          .order(Arel.sql("LENGTH(#{@column}) DESC, #{@column} DESC"))
+        quoted_column = @record.class.connection.quote_column_name(@column)
+        query.select("#{quoted_column} max")
+          .order(Arel.sql("LENGTH(#{quoted_column}) DESC, #{quoted_column} DESC"))
           .first.try :max
       else
         query.maximum @column

--- a/lib/auto_increment/incrementor.rb
+++ b/lib/auto_increment/incrementor.rb
@@ -74,7 +74,7 @@ module AutoIncrement
     end
 
     def string?
-      @initial.instance_of?(String) || column_string?
+      column_string?
     end
 
     def column_string?

--- a/lib/auto_increment/incrementor.rb
+++ b/lib/auto_increment/incrementor.rb
@@ -7,7 +7,7 @@ module AutoIncrement
     def initialize(record, column = nil, **options)
       @record = record
       @column = column || options.fetch(:column, :code)
-      @initial = options.fetch(:initial, 1)
+      @initial = resolve_initial(options)
       @force = options.fetch(:force, false)
       @scope = Array.wrap(options[:scope]).compact
       @model_scope = Array.wrap(options[:model_scope]).compact
@@ -54,7 +54,7 @@ module AutoIncrement
     def maximum
       query = maximum_query
 
-      if string?
+      if column_string?
         query.select("#{@column} max")
           .order(Arel.sql("LENGTH(#{@column}) DESC, #{@column} DESC"))
           .first.try :max
@@ -73,8 +73,10 @@ module AutoIncrement
       max.blank? ? @initial : max.next
     end
 
-    def string?
-      column_string?
+    def resolve_initial(options)
+      return options[:initial] if options.key?(:initial)
+
+      column_string? ? "1" : 1
     end
 
     def column_string?

--- a/spec/lib/active_record_spec.rb
+++ b/spec/lib/active_record_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require "models/account"
 require "models/user"
+require "models/post"
 
 describe AutoIncrement do
   before :all do
@@ -72,5 +73,14 @@ describe AutoIncrement do
 
   describe "uses model scopes" do
     it { expect(@user3_account2.letter_code).to eq("C") }
+  end
+
+  describe "string column with integer initial" do
+    it "increments correctly past the 9-to-10 boundary" do
+      15.times do |i|
+        post = Post.create!
+        expect(post.ref.to_i).to eq(i + 1)
+      end
+    end
   end
 end

--- a/spec/lib/active_record_spec.rb
+++ b/spec/lib/active_record_spec.rb
@@ -120,5 +120,14 @@ describe AutoIncrement do
         end
       }.not_to output(/\[DEPRECATION\]/).to_stderr
     end
+
+    it "does not warn when initial is omitted on a string column (auto-detects)" do
+      expect {
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "posts"
+          auto_increment :ref
+        end
+      }.not_to output(/\[DEPRECATION\]/).to_stderr
+    end
   end
 end

--- a/spec/lib/active_record_spec.rb
+++ b/spec/lib/active_record_spec.rb
@@ -83,4 +83,42 @@ describe AutoIncrement do
       end
     end
   end
+
+  describe "deprecation warning" do
+    it "warns when initial is a string on an integer column" do
+      expect {
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "accounts"
+          auto_increment :code, initial: "A"
+        end
+      }.to output(/\[DEPRECATION\] The initial value type \(String\) does not match the column type \(integer\) for column 'code'.*raise an error in the future/).to_stderr
+    end
+
+    it "warns when initial is an integer on a string column" do
+      expect {
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "posts"
+          auto_increment :ref, initial: 1
+        end
+      }.to output(/\[DEPRECATION\] The initial value type \(Integer\) does not match the column type \(string\) for column 'ref'.*raise an error in the future/).to_stderr
+    end
+
+    it "does not warn when types match (integer column, integer initial)" do
+      expect {
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "accounts"
+          auto_increment :code, initial: 100
+        end
+      }.not_to output(/\[DEPRECATION\]/).to_stderr
+    end
+
+    it "does not warn when types match (string column, string initial)" do
+      expect {
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "posts"
+          auto_increment :ref, initial: "X"
+        end
+      }.not_to output(/\[DEPRECATION\]/).to_stderr
+    end
+  end
 end

--- a/spec/lib/incrementor_spec.rb
+++ b/spec/lib/incrementor_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require "models/account"
 require "models/user"
+require "models/post"
 
 describe AutoIncrement::Incrementor do
   def create_account(code:, name: "seed")
@@ -18,7 +19,7 @@ describe AutoIncrement::Incrementor do
 
   describe "#run" do
     describe "integer column" do
-      it "sets initial value to 1 when no records exist" do
+      it "auto-detects initial value 1 when no initial is given" do
         account = Account.new
         AutoIncrement::Incrementor.new(account).run
         expect(account.code).to eq 1
@@ -44,6 +45,12 @@ describe AutoIncrement::Incrementor do
         user = User.new
         AutoIncrement::Incrementor.new(user, column: :letter_code, initial: "A").run
         expect(user.letter_code).to eq "A"
+      end
+
+      it "auto-detects initial value '1' when no initial is given" do
+        post = Post.new
+        AutoIncrement::Incrementor.new(post, column: :ref).run
+        expect(post.ref).to eq "1"
       end
 
       {

--- a/spec/lib/incrementor_spec.rb
+++ b/spec/lib/incrementor_spec.rb
@@ -17,7 +17,7 @@ describe AutoIncrement::Incrementor do
   end
 
   describe "#run" do
-    describe "integer" do
+    describe "integer column" do
       it "sets initial value to 1 when no records exist" do
         account = Account.new
         AutoIncrement::Incrementor.new(account).run
@@ -39,8 +39,8 @@ describe AutoIncrement::Incrementor do
       end
     end
 
-    describe "string" do
-      it "uses the initial value when no records exist" do
+    describe "string column" do
+      it "sets initial value when no records exist" do
         user = User.new
         AutoIncrement::Incrementor.new(user, column: :letter_code, initial: "A").run
         expect(user.letter_code).to eq "A"
@@ -60,12 +60,9 @@ describe AutoIncrement::Incrementor do
           expect(user.letter_code).to eq next_value
         end
       end
-    end
 
-    describe "string column in DB with integer initial" do
-      it "uses length-aware ordering, not SQL MAX" do
-        values = %w[1 2 3 4 5 6 7 8 9 10]
-        values.each { |v| create_user(code: v) }
+      it "uses length-aware ordering inferred from the column schema" do
+        %w[1 2 3 4 5 6 7 8 9 10].each { |v| create_user(code: v) }
 
         user = User.new
         AutoIncrement::Incrementor.new(user, column: :letter_code, initial: 1).run
@@ -73,14 +70,14 @@ describe AutoIncrement::Incrementor do
       end
     end
 
-    context "when column value is already set" do
-      it "does not change the column if force is false" do
+    describe "force" do
+      it "does not overwrite an existing value when force is false" do
         account = Account.new(code: 5)
         expect { AutoIncrement::Incrementor.new(account).run }
           .not_to change { account.code }
       end
 
-      it "changes the column if force is true" do
+      it "overwrites an existing value when force is true" do
         create_account(code: 10)
         account = Account.new(code: 5)
         AutoIncrement::Incrementor.new(account, force: true).run
@@ -94,7 +91,7 @@ describe AutoIncrement::Incrementor do
       end
     end
 
-    context "scoped increment" do
+    describe "scope" do
       it "only considers records within the same scope" do
         create_account(code: 10, name: "other")
 
@@ -112,38 +109,36 @@ describe AutoIncrement::Incrementor do
         AutoIncrement::Incrementor.new(user, column: :letter_code, initial: "A", model_scope: :with_mark).run
         expect(user.letter_code).to eq "D"
       end
+
+      it "applies model scopes when building the query" do
+        create_user(code: "C", name: "Mark")
+        create_user(code: "A", name: "Other")
+
+        user = User.new(name: "Mark")
+        AutoIncrement::Incrementor.new(user, column: :letter_code, initial: "A", model_scope: :with_mark).run
+        expect(user.letter_code).to eq "D"
+      end
+
+      it "only considers records matching the model scope" do
+        create_account(code: 10, name: "Mark")
+        create_account(code: 5, name: "Other")
+        account = Account.new(name: "Mark")
+        AutoIncrement::Incrementor.new(account, column: :code, initial: 1, model_scope: :only_mark).run
+        expect(account.code).to eq 11
+      end
     end
-  end
 
-  describe "model_scope option" do
-    it "applies model scopes when building the query" do
-      create_user(code: "C", name: "Mark")
-      create_user(code: "A", name: "Other")
+    describe "lock" do
+      it "increments correctly with lock enabled" do
+        create_account(code: 10)
+        account = Account.new
+        incrementor = AutoIncrement::Incrementor.new(account, lock: true)
 
-      user = User.new(name: "Mark")
-      AutoIncrement::Incrementor.new(user, column: :letter_code, initial: "A", model_scope: :with_mark).run
-      expect(user.letter_code).to eq "D"
-    end
+        expect(incrementor.send(:maximum_query).lock_value).to eq true
 
-    it "only considers records matching the model scope for integer columns" do
-      create_account(code: 10, name: "Mark")
-      create_account(code: 5, name: "Other")
-      account = Account.new(name: "Mark")
-      AutoIncrement::Incrementor.new(account, column: :code, initial: 1, model_scope: :only_mark).run
-      expect(account.code).to eq 11
-    end
-  end
-
-  describe "locking the query" do
-    it "increments correctly with lock enabled" do
-      create_account(code: 10)
-      account = Account.new
-      incrementor = AutoIncrement::Incrementor.new(account, lock: true)
-
-      expect(incrementor.send(:maximum_query).lock_value).to eq true
-
-      incrementor.run
-      expect(account.code).to eq 11
+        incrementor.run
+        expect(account.code).to eq 11
+      end
     end
   end
 end

--- a/spec/lib/incrementor_spec.rb
+++ b/spec/lib/incrementor_spec.rb
@@ -62,6 +62,17 @@ describe AutoIncrement::Incrementor do
       end
     end
 
+    describe "string column in DB with integer initial" do
+      it "uses length-aware ordering, not SQL MAX" do
+        values = %w[1 2 3 4 5 6 7 8 9 10]
+        values.each { |v| create_user(code: v) }
+
+        user = User.new
+        AutoIncrement::Incrementor.new(user, column: :letter_code, initial: 1).run
+        expect(user.letter_code).to eq "11"
+      end
+    end
+
     context "when column value is already set" do
       it "does not change the column if force is false" do
         account = Account.new(code: 5)

--- a/spec/models/post.rb
+++ b/spec/models/post.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Spec +Post+ — string column with default integer initial
+class Post < ActiveRecord::Base
+  auto_increment :ref
+end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -12,3 +12,8 @@ ActiveRecord::Migration.create_table :users do |t|
   t.integer :account_id
   t.string :letter_code
 end
+
+# +ActiveRecord+ migration for Posts (string column, integer initial)
+ActiveRecord::Migration.create_table :posts do |t|
+  t.string :ref
+end


### PR DESCRIPTION
## Changes

### Auto-detect initial value type
When `initial` is not explicitly set, `Incrementor` now infers the default based on the database column type: `"1"` for string/text columns, `1` for integer columns. This prevents the common pitfall of a mismatched default.

### Deprecation warning
When `initial` is *explicitly* passed with a type that doesn't match the column (e.g. `auto_increment :ref, initial: 1` on a `string` column), a deprecation warning is emitted at class-load time. This fires once per model, not on every record creation.

### String column fix
When the DB column is a string type but `initial` is an integer, the SQL `MAX()` function does lexicographic comparison, causing `'9' > '10'` and duplicate values from record 10 onward. Fixed by checking the actual DB column type via `columns_hash`, string/text columns now use length-aware `ORDER BY` and `String#next` for incrementing.

Closes #18
